### PR TITLE
fix: lorem generator word and sentence values

### DIFF
--- a/client/src/pages/NewBlog.jsx
+++ b/client/src/pages/NewBlog.jsx
@@ -74,11 +74,11 @@ export default function NewBlog() {
     const handleGenerate = () => {
         const lorem = new LoremIpsum({
             sentencesPerParagraph:{
-                max: loremOptions.maxSentencePerParagraph,
+                max: loremOptions.sentencePerParagraph,
                 min: loremOptions.minSentencePerParagraph
             },
             wordsPerSentence: {
-                max: loremOptions.maxWordPerSentence,
+                max: loremOptions.wordPerSentence,
                 min: loremOptions.minWordPerSentence
             }
         })


### PR DESCRIPTION
It doesn't matter which value we choose in the slider. We never use them if we didn't send them to the generator. We can give the values we get from the slider as the generator max values.